### PR TITLE
Add interface class, Hitnmiss::Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,6 @@ TODO: Write usage instructions here
 
 ## ToDo
 
-- Write an interface class with pure virtual methods that defines the
-  interface that a driver must conform to. Also, make sure the
-  InMemoryDriver uses it.
 - Add a test to the ".fetch" that makes sure it first calls
   `generate_key` and then "attempts to obtain the cached value".
 - Write a useful README.md that will help people understand how to use

--- a/lib/hitnmiss.rb
+++ b/lib/hitnmiss.rb
@@ -2,6 +2,7 @@ require "hitnmiss/version"
 require "hitnmiss/errors"
 require "hitnmiss/repository"
 require "hitnmiss/entity"
+require "hitnmiss/driver"
 require "hitnmiss/in_memory_driver"
 
 module Hitnmiss

--- a/lib/hitnmiss/driver.rb
+++ b/lib/hitnmiss/driver.rb
@@ -1,0 +1,11 @@
+module Hitnmiss
+  class Driver
+    def set(key, value, expiration_in_seconds)
+      raise Hitnmiss::Errors::NotImplemented
+    end
+
+    def get(key)
+      raise Hitnmiss::Errors::NotImplemented
+    end
+  end
+end

--- a/lib/hitnmiss/in_memory_driver.rb
+++ b/lib/hitnmiss/in_memory_driver.rb
@@ -1,5 +1,5 @@
 module Hitnmiss
-  class InMemoryDriver
+  class InMemoryDriver < Hitnmiss::Driver
     def initialize
       @cache = {}
     end

--- a/spec/lib/hitnmiss/driver_spec.rb
+++ b/spec/lib/hitnmiss/driver_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Hitnmiss::Driver do
+  it "constructs an instance of Hitnmiss::Driver" do
+    expect(subject).to be_a(Hitnmiss::Driver)
+  end
+
+  describe "#set" do
+    it "raises error indicating not implemented" do
+      expect { subject.set(double('key'),
+                           double('value'),
+                           double('expiration')) }.to \
+      raise_error(Hitnmiss::Errors::NotImplemented)
+    end
+  end
+
+  describe "#get" do
+    it "raises error indicating not implemented" do
+      expect { subject.get(double('key')) }.to \
+      raise_error(Hitnmiss::Errors::NotImplemented)
+    end
+  end
+end


### PR DESCRIPTION
Why you made the change:

I did this so that there would be class to aid people in making sure
they conformed to the interface of a driver if they are developing a new
driver.

How the change addresses the need:

This aids in this by raising exceptions if one of the driver methods is
used and the inheriting class neglects to implement it.
