### PR TITLE
Make the in memory driver threadsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Make the in memory driver threadsafe
+
 #### v0.1.0
 
 * Added driver registry to centrally manage instantiated drivers

--- a/lib/hitnmiss/in_memory_driver.rb
+++ b/lib/hitnmiss/in_memory_driver.rb
@@ -1,20 +1,28 @@
 module Hitnmiss
   class InMemoryDriver < Hitnmiss::Driver
     def initialize
+      @mutex = Mutex.new
       @cache = {}
     end
 
     def set(key, value, expiration_in_seconds)
       expiration = Time.now.utc.to_i + expiration_in_seconds
-      @cache[key] = { 'value' => value, 'expiration' => expiration }
+      @mutex.synchronize do
+        @cache[key] = { 'value' => value, 'expiration' => expiration }
+      end
     end
 
     def get(key)
-      if @cache[key]
-        if Time.now.utc.to_i > @cache[key]['expiration']
+      cached_entity = nil
+      @mutex.synchronize do
+        cached_entity = @cache[key].dup if @cache[key]
+      end
+
+      if cached_entity
+        if Time.now.utc.to_i > cached_entity['expiration']
           return nil
         else
-          return @cache[key]['value']
+          return cached_entity['value']
         end
       else
         return nil


### PR DESCRIPTION
Why you made the change:

I did this so that we could use this library safely in threaded systems.
