### PR TITLE
Move repository driver management into sep file

### DIFF
--- a/lib/hitnmiss/repository.rb
+++ b/lib/hitnmiss/repository.rb
@@ -1,4 +1,5 @@
 require 'hitnmiss/repository/fetcher'
+require 'hitnmiss/repository/driver_management'
 
 module Hitnmiss
   module Repository
@@ -8,20 +9,12 @@ module Hitnmiss
 
     def self.included(mod)
       mod.include(Fetcher)
+      mod.extend(DriverManagement)
       mod.extend(ClassMethods)
       mod.include(InstanceMethods)
-      mod.driver :in_memory
     end
 
     module ClassMethods
-      def driver(driver_name=nil)
-        if driver_name
-          @driver_name = driver_name
-        else
-          @driver_name
-        end
-      end
-
       def default_expiration(expiration_in_seconds=nil)
         if expiration_in_seconds
           @default_expiration = expiration_in_seconds

--- a/lib/hitnmiss/repository/driver_management.rb
+++ b/lib/hitnmiss/repository/driver_management.rb
@@ -1,0 +1,17 @@
+module Hitnmiss
+  module Repository
+    module DriverManagement
+      def self.extended(mod)
+        mod.driver :in_memory
+      end
+
+      def driver(driver_name=nil)
+        if driver_name
+          @driver_name = driver_name
+        else
+          @driver_name
+        end
+      end
+    end
+  end
+end

--- a/spec/hitnmiss/repository/driver_management_spec.rb
+++ b/spec/hitnmiss/repository/driver_management_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+RSpec.describe Hitnmiss::Repository::DriverManagement do
+  describe '.driver' do
+    context 'when given a driver identifier' do
+      it 'sets driver to a registered driver' do
+        repo_klass = Class.new do
+          extend Hitnmiss::Repository::DriverManagement
+          driver :some_driver
+        end
+
+        driver_name = repo_klass.instance_variable_get(:@driver_name)
+        expect(driver_name).to eq(:some_driver)
+      end
+    end
+
+    context 'when NOT given a driver identifier' do
+      context 'when driver has been set' do
+        it 'returns the driver identifier' do
+          repo_klass = Class.new do
+            extend Hitnmiss::Repository::DriverManagement
+            driver :some_driver
+          end
+
+          driver_name = repo_klass.driver
+          expect(driver_name).to eq(:some_driver)
+        end
+      end
+
+      context 'when driver has NOT been set' do
+        it 'returns identifier for the default driver' do
+          repo_klass = Class.new do
+            extend Hitnmiss::Repository::DriverManagement
+          end
+
+          driver_name = repo_klass.driver
+          expect(driver_name).to eq(:in_memory)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Why you made the change:

I did this so that things could be better modularized and organized. This will
potentially enable easier creation of other repositories of various types in the
future.
