### PR TITLE
Move key generation concerns to sub-module

### DIFF
--- a/lib/hitnmiss/in_memory_driver.rb
+++ b/lib/hitnmiss/in_memory_driver.rb
@@ -54,7 +54,7 @@ module Hitnmiss
     end
 
     def match_keyspace?(key, keyspace)
-      regex = Regexp.new("^#{keyspace}\\" + Repository::KEY_COMPONENT_SEPARATOR)
+      regex = Regexp.new("^#{keyspace}\\" + Repository::KeyGeneration::KEY_COMPONENT_SEPARATOR)
       return regex.match(key)
     end
   end

--- a/lib/hitnmiss/repository.rb
+++ b/lib/hitnmiss/repository.rb
@@ -1,15 +1,15 @@
 require 'hitnmiss/repository/fetcher'
 require 'hitnmiss/repository/driver_management'
+require 'hitnmiss/repository/key_generation'
 
 module Hitnmiss
   module Repository
-    KEY_COMPONENT_SEPARATOR = '.'.freeze
-    KEY_COMPONENT_TYPE_SEPARATOR = ':'.freeze
     class UnsupportedDriverResponse < StandardError; end
 
     def self.included(mod)
       mod.include(Fetcher)
       mod.extend(DriverManagement)
+      mod.include(KeyGeneration)
       mod.extend(ClassMethods)
       mod.include(InstanceMethods)
     end
@@ -21,10 +21,6 @@ module Hitnmiss
         else
           @default_expiration 
         end
-      end
-
-      def keyspace
-        name
       end
     end
 
@@ -78,14 +74,6 @@ module Hitnmiss
           Hitnmiss.driver(self.class.driver).set(generate_key(*args), cacheable_entity.value,
                      self.class.default_expiration)
         end
-      end
-
-      def generate_key(*args)
-        components = args.map do |arg|
-          "#{arg.class.name}#{KEY_COMPONENT_TYPE_SEPARATOR}#{arg}"
-        end
-        return "#{self.class.keyspace}#{KEY_COMPONENT_SEPARATOR}" \
-               "#{components.join(KEY_COMPONENT_SEPARATOR)}"
       end
     end
   end

--- a/lib/hitnmiss/repository/key_generation.rb
+++ b/lib/hitnmiss/repository/key_generation.rb
@@ -1,0 +1,31 @@
+module Hitnmiss
+  module Repository
+    module KeyGeneration
+      KEY_COMPONENT_SEPARATOR = '.'.freeze
+      KEY_COMPONENT_TYPE_SEPARATOR = ':'.freeze
+
+      def self.included(mod)
+        mod.extend(ClassMethods)
+        mod.include(InstanceMethods)
+      end
+
+      module ClassMethods
+        def keyspace
+          name
+        end
+      end
+
+      module InstanceMethods
+        private
+
+        def generate_key(*args)
+          components = args.map do |arg|
+            "#{arg.class.name}#{KEY_COMPONENT_TYPE_SEPARATOR}#{arg}"
+          end
+          return "#{self.class.keyspace}#{KEY_COMPONENT_SEPARATOR}" \
+                 "#{components.join(KEY_COMPONENT_SEPARATOR)}"
+        end
+      end
+    end
+  end
+end

--- a/spec/hitnmiss/repository/key_generation_spec.rb
+++ b/spec/hitnmiss/repository/key_generation_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe Hitnmiss::Repository::KeyGeneration do
+  describe '#generate_key' do
+    it 'generates a key from the class and the given arguments' do
+      repo_klass = Class.new do
+        include Hitnmiss::Repository::KeyGeneration
+      end
+
+      allow(repo_klass).to receive(:name).and_return('HooptyJack')
+
+      repository = repo_klass.new
+
+      expect(repository.send(:generate_key, 'true', true, 1, 'zar')).to \
+        eq('HooptyJack.String:true.TrueClass:true.Fixnum:1.String:zar')
+    end
+  end
+end

--- a/spec/hitnmiss/repository_spec.rb
+++ b/spec/hitnmiss/repository_spec.rb
@@ -83,21 +83,6 @@ describe Hitnmiss::Repository do
     end
   end
 
-  describe '#generate_key' do
-    it 'generates a key from the class and the given arguments' do
-      repo_klass = Class.new do
-        include Hitnmiss::Repository
-      end
-
-      allow(repo_klass).to receive(:name).and_return('HooptyJack')
-
-      repository = repo_klass.new
-
-      expect(repository.send(:generate_key, 'true', true, 1, 'zar')).to \
-        eq('HooptyJack.String:true.TrueClass:true.Fixnum:1.String:zar')
-    end
-  end
-
   describe '#fetch' do
     it 'raises error indicating not implemented' do
       repo_klass = Class.new do


### PR DESCRIPTION
Why you made the change:

I did this for one to better organized the key generation concern. However, most
importantly to facilitate sharing of the key generation logic to facilitate
creation of other types of repositories. This is especially application to what
will most likely be the new background refresh repository.
