### PR TITLE
Add private `get_from_cache` method to Repository

### DIFF
--- a/lib/hitnmiss/repository.rb
+++ b/lib/hitnmiss/repository.rb
@@ -69,7 +69,7 @@ module Hitnmiss
       end
 
       def get(*args)
-        hit_or_miss = Hitnmiss.driver(self.class.driver).get(generate_key(*args))
+        hit_or_miss = get_from_cache(*args)
         if hit_or_miss.is_a?(Hitnmiss::Driver::Miss)
           return prime(*args)
         elsif hit_or_miss.is_a?(Hitnmiss::Driver::Hit)
@@ -86,6 +86,10 @@ module Hitnmiss
       end
 
       private
+
+      def get_from_cache(*args)
+        Hitnmiss.driver(self.class.driver).get(generate_key(*args))
+      end
 
       def cache_entity(args, cacheable_entity)
         if cacheable_entity.expiration


### PR DESCRIPTION
Why you made the change:

I added this method for a couple reasons.
1. It extracts the concerns of driver lookup, key generation, and driver
   interfacing out of the Repository public API `get` method.
2. It provides a nice internal method for use in implementing other Repository
   public API methods. For example if we wanted to implement a public `stale?`
   method on Repository, we would need to get a Hit or Miss from the driver but
   wouldn't want to automatically prime the cache, etc. that is done in the public
   API `get` method.
