### PR TITLE
Correct typo in UnregisterdDriver

### DIFF
--- a/lib/hitnmiss/driver_registry.rb
+++ b/lib/hitnmiss/driver_registry.rb
@@ -10,7 +10,7 @@ module Hitnmiss
 
     def get(name)
       @registry.fetch(name) do |name|
-        raise Errors::UnregisterdDriver.new("#{name} is not a registered driver")
+        raise Errors::UnregisteredDriver.new("#{name} is not a registered driver")
       end
     end
   end

--- a/lib/hitnmiss/errors.rb
+++ b/lib/hitnmiss/errors.rb
@@ -4,6 +4,6 @@ module Hitnmiss
 
     class NotImplemented < Error; end
 
-    class UnregisterdDriver < Error; end
+    class UnregisteredDriver < Error; end
   end
 end

--- a/spec/hitnmiss/driver_registry_spec.rb
+++ b/spec/hitnmiss/driver_registry_spec.rb
@@ -29,8 +29,8 @@ describe Hitnmiss::DriverRegistry do
     end
 
     context "when the driver is not registered in the registry" do
-      it "raises an UnregisterdDriver exception" do
-        expect { subject.get("name") }.to raise_error(Hitnmiss::Errors::UnregisterdDriver)
+      it "raises an UnregisteredDriver exception" do
+        expect { subject.get("name") }.to raise_error(Hitnmiss::Errors::UnregisteredDriver)
       end
     end
   end


### PR DESCRIPTION
Why you made the change:

I did this so that we wouldn't have a needless typo in the code base. This is
technically a public interface breaking change so I wanted to group it with the
other changes in this branch because they are also public interface breaking
changes.
