### PR TITLE
Rework set logger interface to be instance based

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ versions, as well as provide a rough history.
 
 #### Next Release
 
+* Changed logging interface from class based to instance based
 * Added logging support to BackgroundRefreshRepository and Repository
 
 #### v2.1.0

--- a/lib/hitnmiss/background_refresh_repository.rb
+++ b/lib/hitnmiss/background_refresh_repository.rb
@@ -6,7 +6,7 @@ module Hitnmiss
     class RefreshIntervalRequired < StandardError; end
 
     def self.included(mod)
-      mod.extend(OptionalLogger::LoggerManagement)
+      mod.include(OptionalLogger::LoggerManagement)
       mod.include(Repository::CacheManagement)
       mod.extend(ClassMethods)
       mod.include(InstanceMethods)
@@ -34,39 +34,39 @@ module Hitnmiss
       end
 
       def refresh(*args, swallow_exceptions: [])
-        self.class.logger.debug("hitnmiss: refresh(#{args.inspect}, swallow_exceptions: #{swallow_exceptions.inspect}) called")
+        logger.debug("hitnmiss: refresh(#{args.inspect}, swallow_exceptions: #{swallow_exceptions.inspect}) called")
         if swallow_exceptions.empty?
-          self.class.logger.debug("hitnmiss: refresh(#{args.inspect}, swallow_exceptions: #{swallow_exceptions.inspect}) about to check stale?")
+          logger.debug("hitnmiss: refresh(#{args.inspect}, swallow_exceptions: #{swallow_exceptions.inspect}) about to check stale?")
           if stale?(*args)
-            self.class.logger.debug("hitnmiss: refresh(#{args.inspect}, swallow_exceptions: #{swallow_exceptions.inspect}) is stale, about to prime")
+            logger.debug("hitnmiss: refresh(#{args.inspect}, swallow_exceptions: #{swallow_exceptions.inspect}) is stale, about to prime")
             prime(*args)
           end
         else
           begin
-            self.class.logger.debug("hitnmiss: refresh(#{args.inspect}, swallow_exceptions: #{swallow_exceptions.inspect}) about to check stale?")
+            logger.debug("hitnmiss: refresh(#{args.inspect}, swallow_exceptions: #{swallow_exceptions.inspect}) about to check stale?")
             if stale?(*args)
-              self.class.logger.debug("hitnmiss: refresh(#{args.inspect}, swallow_exceptions: #{swallow_exceptions.inspect}) is stale, about to prime")
+              logger.debug("hitnmiss: refresh(#{args.inspect}, swallow_exceptions: #{swallow_exceptions.inspect}) is stale, about to prime")
               prime(*args)
             end
           rescue *swallow_exceptions => e
-            self.class.logger.error("hitnmiss: refresh(#{args.inspect}, swallow_exceptions: #{swallow_exceptions.inspect}) swallowed exception: #{e.inspect}")
-            self.class.logger.error(e.backtrace.join("\n"))
+            logger.error("hitnmiss: refresh(#{args.inspect}, swallow_exceptions: #{swallow_exceptions.inspect}) swallowed exception: #{e.inspect}")
+            logger.error(e.backtrace.join("\n"))
           end
         end
       end
 
       def background_refresh(*args, swallow_exceptions: [])
-        self.class.logger.debug("hitnmiss: background_refresh(#{args.inspect}) called")
+        logger.debug("hitnmiss: background_refresh(#{args.inspect}) called")
         @refresh_thread = Thread.new(self, args) do |repository, args|
           while(true) do
-            repository.class.logger.debug("hitnmiss: background_refresh(#{args.inspect}): about to call refresh()")
+            repository.logger.debug("hitnmiss: background_refresh(#{args.inspect}): about to call refresh()")
             refresh(*args, swallow_exceptions: swallow_exceptions)
-            repository.class.logger.debug("hitnmiss: background_refresh(#{args.inspect}): about to sleep for #{repository.class.refresh_interval}")
+            repository.logger.debug("hitnmiss: background_refresh(#{args.inspect}): about to sleep for #{repository.class.refresh_interval}")
             sleep repository.class.refresh_interval
           end
         end
         @refresh_thread.abort_on_exception = true
-        self.class.logger.debug("hitnmiss: background_refresh(#{args.inspect}) enabled abort on exception")
+        logger.debug("hitnmiss: background_refresh(#{args.inspect}) enabled abort on exception")
       end
 
       private

--- a/lib/hitnmiss/repository.rb
+++ b/lib/hitnmiss/repository.rb
@@ -3,7 +3,7 @@ require 'hitnmiss/repository/cache_management'
 module Hitnmiss
   module Repository
     def self.included(mod)
-      mod.extend(OptionalLogger::LoggerManagement)
+      mod.include(OptionalLogger::LoggerManagement)
       mod.include(CacheManagement)
       mod.extend(ClassMethods)
       mod.include(InstanceMethods)

--- a/spec/hitnmiss/background_refresh_repository_spec.rb
+++ b/spec/hitnmiss/background_refresh_repository_spec.rb
@@ -1,20 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe Hitnmiss::BackgroundRefreshRepository do
-  describe '.logger' do
-    it 'sets the logger using optional logger' do
-      mylogger = double('my logger')
-
-      repo_klass = Class.new do
-        include Hitnmiss::BackgroundRefreshRepository
-        logger(mylogger)
-      end
-
-      expect(repo_klass.logger).to be_a(OptionalLogger::Logger)
-      expect(repo_klass.logger.wrapped_logger).to eq(mylogger)
-    end
-  end
-
   describe '.refresh_interval' do
     context 'when given a refresh interval' do
       it 'set the refresh interval for the cache repository' do
@@ -53,6 +39,24 @@ RSpec.describe Hitnmiss::BackgroundRefreshRepository do
           expect(actual_interval).to eq(nil)
         end
       end
+    end
+  end
+
+  describe '#logger' do
+    it 'sets the logger using optional logger' do
+      mylogger = double('my logger')
+      interval = double('interval')
+
+      repo_klass = Class.new do
+        include Hitnmiss::BackgroundRefreshRepository
+        refresh_interval interval
+      end
+
+      repo = repo_klass.new
+      repo.logger(mylogger)
+
+      expect(repo.logger).to be_a(OptionalLogger::Logger)
+      expect(repo.logger.wrapped_logger).to eq(mylogger)
     end
   end
 

--- a/spec/hitnmiss/repository_spec.rb
+++ b/spec/hitnmiss/repository_spec.rb
@@ -1,17 +1,18 @@
 require 'spec_helper'
 
 describe Hitnmiss::Repository do
-  describe '.logger' do
+  describe '#logger' do
     it 'sets the logger using optional logger' do
       mylogger = double('my logger')
 
       repo_klass = Class.new do
         include Hitnmiss::Repository
-        logger(mylogger)
       end
+      repo = repo_klass.new
+      repo.logger(mylogger)
 
-      expect(repo_klass.logger).to be_a(OptionalLogger::Logger)
-      expect(repo_klass.logger.wrapped_logger).to eq(mylogger)
+      expect(repo.logger).to be_a(OptionalLogger::Logger)
+      expect(repo.logger.wrapped_logger).to eq(mylogger)
     end
   end
 


### PR DESCRIPTION
Why you made the change:

I did this because having it be classed based doesn't allow it to be
easily consumed in all cases.